### PR TITLE
nil for cache store

### DIFF
--- a/lib/active_support/cache/iron_cache_store.rb
+++ b/lib/active_support/cache/iron_cache_store.rb
@@ -31,7 +31,8 @@ module ActiveSupport
         item = nil
 
         with_namespace(key, options) do |cache, k|
-          item = cache.get(k).value
+          item = cache.get(k)
+          item = item.value unless item.nil?
         end
 
         deserialize_entry(item)


### PR DESCRIPTION
Fixes error with reading nonexistent key for rails cache store
