### PR TITLE
[FAILING EXAMPLE] Clearing and counters

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,3 @@
+iron: # https://hud.iron.io/dashboard
+  token: 'YOUR_TOKEN_FROM_DASHBOARD'
+  project_id: 'YOUR_PROJECT_ID_FROM_DASHBOARD'

--- a/test/test_clearing.rb
+++ b/test/test_clearing.rb
@@ -1,0 +1,29 @@
+require 'test/unit'
+require 'yaml'
+require File.expand_path('test_base.rb', File.dirname(__FILE__))
+
+class AboutClearing < TestBase
+  def setup
+    super
+    @client.cache_name = 'test_clearing_incrementors'
+  end
+
+  def test_that_it_deletes_a_single_incrementor_FAILING
+    clear_cache
+    
+    the_increment_key = "count"
+    
+    @client.items.increment the_increment_key
+    
+    clear_cache
+
+    actual = @client.items.get(the_increment_key)
+
+    assert_true actual.nil?, "Expected <nil>, actually got <#{actual.value}>"
+  end
+
+  def test_that_asking_for_a_missing_item_returns_nil
+    assert_nil @client.items.get("xxx_nonsense_xxx"), "Just to show that we are right to expect nil"
+  end
+end
+


### PR DESCRIPTION
Shows that incrementor keys are not deleted when clearing a cache.
